### PR TITLE
Show building selector for all users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,8 +29,8 @@ const ProtectedRoute = ({ children, allowedRoles }: { children: React.ReactNode;
     return <LoginForm />;
   }
   
-  // For admin users, check if they have selected a building
-  if (user.role === 'admin' && !selectedBuilding) {
+  // Require a building to be selected for all users
+  if (!selectedBuilding) {
     return <LoginForm />;
   }
   
@@ -50,8 +50,7 @@ const AppRoutes = () => {
       <Route path="/" element={<Layout />}>
         <Route index element={
           user ? (
-            // For admin users, check if they have completed building selection
-            user.role === 'admin' && !selectedBuilding ? (
+            !selectedBuilding ? (
               <LoginForm />
             ) : (
               <Navigate to={user.role === 'admin' ? '/admin' : user.role === 'junta' ? '/junta' : '/owner'} replace />

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -18,16 +18,10 @@ const LoginForm: React.FC = () => {
 
   // Effect to handle admin flow after successful login
   useEffect(() => {
-    if (user?.role === 'admin' && step === 'login') {
+    if (user && step === 'login') {
       setStep('condominium');
-    } else if (user?.role !== 'admin' && step === 'login') {
-      // For non-admin users, check if building selection is required
-      const userBuildings = buildings.filter(b => b.condominiumId === selectedCondominium?.id);
-      if (userBuildings.length > 1 && !selectedBuilding) {
-        setStep('building');
-      }
     }
-  }, [user, step, selectedCondominium, selectedBuilding, buildings]);
+  }, [user, step]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -53,8 +47,8 @@ const LoginForm: React.FC = () => {
     }
   };
 
-  // Show condominium selection for admin after login
-  if (user?.role === 'admin' && step === 'condominium') {
+  // Show condominium selection after login
+  if (step === 'condominium') {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-blue-50 p-4">
         <Card className="w-full max-w-2xl shadow-xl border-0">
@@ -74,9 +68,8 @@ const LoginForm: React.FC = () => {
     );
   }
 
-  // Show building selection for users who need to select a building
-  if ((user?.role === 'admin' && step === 'building' && selectedCondominium) || 
-      (user?.role !== 'admin' && step === 'building')) {
+  // Show building selection once a condominium is chosen
+  if (step === 'building' && selectedCondominium) {
     const condominiumBuildings = buildings.filter(b => b.condominiumId === selectedCondominium?.id);
     
     return (

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -113,38 +113,20 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const savedUser = localStorage.getItem('codomi_user');
     const savedBuilding = localStorage.getItem('codomi_selected_building');
     const savedCondominium = localStorage.getItem('codomi_selected_condominium');
-    
+
     if (savedUser) {
       const parsedUser = JSON.parse(savedUser);
       setUser(parsedUser);
-      
-      // For non-admin users, auto-set condominium and building
-      if (parsedUser.role !== 'admin') {
-        const defaultCondominium = mockCondominiums[0];
-        setSelectedCondominium(defaultCondominium);
-        localStorage.setItem('codomi_selected_condominium', JSON.stringify(defaultCondominium));
-        
-        // Auto-select building if user has only one available building
+
+      if (savedCondominium) {
+        setSelectedCondominium(JSON.parse(savedCondominium));
+      }
+
+      if (savedBuilding) {
+        const parsedBuilding = JSON.parse(savedBuilding);
         const userBuildings = getUserBuildings(parsedUser);
-        if (userBuildings.length === 1) {
-          setSelectedBuilding(userBuildings[0]);
-          localStorage.setItem('codomi_selected_building', JSON.stringify(userBuildings[0]));
-        } else if (savedBuilding) {
-          const parsedBuilding = JSON.parse(savedBuilding);
-          // Verify the building is still available to the user
-          if (userBuildings.some(b => b.id === parsedBuilding.id)) {
-            setSelectedBuilding(parsedBuilding);
-          } else {
-            localStorage.removeItem('codomi_selected_building');
-          }
-        }
-      } else {
-        // For admin users, restore saved selections
-        if (savedBuilding) {
-          setSelectedBuilding(JSON.parse(savedBuilding));
-        }
-        if (savedCondominium) {
-          setSelectedCondominium(JSON.parse(savedCondominium));
+        if (userBuildings.some(b => b.id === parsedBuilding.id)) {
+          setSelectedBuilding(parsedBuilding);
         }
       }
     }
@@ -162,30 +144,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (foundUser && password === '123456') {
       setUser(foundUser);
       localStorage.setItem('codomi_user', JSON.stringify(foundUser));
-      
-      if (foundUser.role === 'admin') {
-        // Clear selections for admin users to force fresh selection
-        setSelectedCondominium(null);
-        setSelectedBuilding(null);
-        localStorage.removeItem('codomi_selected_condominium');
-        localStorage.removeItem('codomi_selected_building');
-      } else {
-        // For non-admin users, auto-set condominium
-        const defaultCondominium = mockCondominiums[0];
-        setSelectedCondominium(defaultCondominium);
-        localStorage.setItem('codomi_selected_condominium', JSON.stringify(defaultCondominium));
-        
-        // Auto-select building if user has only one available
-        const userBuildings = getUserBuildings(foundUser);
-        if (userBuildings.length === 1) {
-          setSelectedBuilding(userBuildings[0]);
-          localStorage.setItem('codomi_selected_building', JSON.stringify(userBuildings[0]));
-        } else {
-          // User must select a building - don't auto-select
-          setSelectedBuilding(null);
-          localStorage.removeItem('codomi_selected_building');
-        }
-      }
+
+      // Clear previous selections so every user chooses again
+      setSelectedCondominium(null);
+      setSelectedBuilding(null);
+      localStorage.removeItem('codomi_selected_condominium');
+      localStorage.removeItem('codomi_selected_building');
       
       setIsLoading(false);
       return true;


### PR DESCRIPTION
## Summary
- require building selection for any role before entering app
- make login flow always display condominium and building selectors
- restore saved selections without defaults and clear them at login

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6876f4675a188329891399bfa2c941e1